### PR TITLE
Britify

### DIFF
--- a/src/logic/logic.sakuria.ts
+++ b/src/logic/logic.sakuria.ts
@@ -223,15 +223,27 @@ export function uwufy(sentence: string): string {
 /**
  * Britishize a sentence
  * @param sentence the sentence to britishize
- * @author Geoxor
+ * @author Geoxor & MaidMarija
  */
 export function britify(sentence: string): string {
-  return sentence
-    .replace(/fuck/g, "fock")
-    .replace(/ing/g, "in'")
-    .replace(/what/g, "wot")
-    .replace(/(man)|(bro)|(buddy)/g, "cunt")
-    .replace(/a/g, "o");
+
+  // first delete any disgusting american dialect (IMPORTANT, NEEDS IMPROVEMENT)
+  sentence = sentence.replace(/mom/g, "mum");
+
+  // and make some suitable other word replacements
+  sentence = sentence.replace(/what/g, "wot");
+  // sentence = sentence.replace(/fuck/g, "fock");
+
+  // where the fuck did you get this from
+  // sentence = sentence.replace(/a/g, "o");
+
+  // personally "what the fuck mate" sounds better than "what the fuck cunt"
+  sentence = sentence.replace(/man|bud(dy)?|bro/g, "mate");
+
+  // we don't use t (sometimes) nor the -ing suffix
+  sentence = sentence.replace(/(?<!\s|k|x|')t+(?!(\w*')|h|ch|ion)|(?<=\win)g/g, "'");
+
+  return sentence;
 }
 
 /**


### PR DESCRIPTION
I planned this shit out while on a walk, trying to say whatever I could in a strong accent I only half have while not looking like a madman.

there are some false positives in the removal of the hard spoken `t` which can come about from words like "caution" because the RegEx doesn't account for certain graphemes. These unnoticed graphemes include:

- `tu`, `ti`, `te` for the phoneme `tʃ` (eg. future, action, righteous)
- `st` for the phoneme `s` (eg. listen)
- `ft` for the phoneme `f` (eg. often)
- `ti` for the phoneme `ʃ` (eg. station)
- `et` for the phoneme `eɪ` (eg. filet)

Reason being I forgot about some of them and some of them have way too many collisions which will need something like conversion to IPA to solve. I kept the code you included and commented out the bits I disagreed with. Feel free to shuffle it up a bit if I'm too posh to have a "true British" accent.