### PR TITLE
fix(Say): Disabled mentions parsing.

### DIFF
--- a/src/commands/fun/say.shaii.ts
+++ b/src/commands/fun/say.shaii.ts
@@ -7,6 +7,9 @@ export default defineCommand({
   execute: (message) => {
     if (message.mentions.everyone) return "you can't make me tag everyone idiot";
     message.delete();
-    return message.args.join(" ");
+    return {
+      content: message.args.join(" "),
+      allowedMentions: { parse: [] }
+    };
   },
 });


### PR DESCRIPTION
This should fix the Say command to not ping roles.
> This is cause of the accent in bot commands.