### PR TITLE
2 new commands + small refactor on text commands

### DIFF
--- a/src/commands/fun/brainfuck.shaii.ts
+++ b/src/commands/fun/brainfuck.shaii.ts
@@ -1,0 +1,24 @@
+import { textToBrainfuck } from "../../logic/logic.shaii";
+import { defineCommand } from "../../types";
+import { SLURS } from "../../constants";
+import { randomChoice } from "../../logic/logic.shaii";
+import { Readable } from "stream";
+
+export default defineCommand({
+  name: "brainfuck",
+  category: "FUN",
+  usage: "brainfuck <sentence>",
+  aliases: [],
+  description: "Translates your sentence to brainfuck esoteric language",
+  requiresProcessing: false,
+  execute: async (message) => {
+    if (message.args.length === 0) return `what to you want to translate ${randomChoice(SLURS)}`;
+    const response: string = textToBrainfuck(message.args.join(" "));
+	if (response.length > 2000) {
+		return {
+			content: "bro the result is too big gonna put it in a file",
+			files: [{ name: "shit.bf", attachment: Readable.from(response) }],
+		};
+	} else return response;
+  },
+});

--- a/src/commands/fun/brainfuck.shaii.ts
+++ b/src/commands/fun/brainfuck.shaii.ts
@@ -14,11 +14,11 @@ export default defineCommand({
   execute: async (message) => {
     if (message.args.length === 0) return `what to you want to translate ${randomChoice(SLURS)}`;
     const response: string = textToBrainfuck(message.args.join(" "));
-	if (response.length > 2000) {
-		return {
-			content: "bro the result is too big gonna put it in a file",
-			files: [{ name: "shit.bf", attachment: Readable.from(response) }],
-		};
-	} else return response;
+    if (response.length > 2000) {
+      return {
+        content: "bro the result is too big gonna put it in a file",
+        files: [{ name: "shit.bf", attachment: Readable.from(response) }],
+      };
+    } else return response;
   },
 });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -26,6 +26,7 @@ import match from "./fun/match.shaii";
 import fact from "./fun/funfact.shaii";
 import say from "./fun/say.shaii";
 import spongify from "./fun/spongify.shaii";
+import brainfuck from "./fun/brainfuck.shaii";
 
 // moderation commands
 import clear from "./moderation/clear.shaii";
@@ -94,6 +95,7 @@ export const getCommands = async () => {
     battle,
     say,
     spongify,
+    brainfuck,
   ];
 
   return commands;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@
 
 import { genCommands } from "../logic/logic.shaii";
 import { imageProcessors } from "../logic/imageProcessors.shaii";
+import { textProcessors } from "../logic/textProcessors.shaii";
 import logger from "../shaii/Logger.shaii";
 
 // economy game commands

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,13 +20,16 @@ import dicksize from "./fun/dicksize.shaii";
 import tts from "./fun/tts.shaii";
 import mors from "./fun/mors.shaii";
 import traceAnime from "./fun/trace.shaii";
-import uwuify from "./fun/uwufy.shaii";
-import britify from "./fun/britify.shaii";
 import match from "./fun/match.shaii";
 import fact from "./fun/funfact.shaii";
 import say from "./fun/say.shaii";
-import spongify from "./fun/spongify.shaii";
-import brainfuck from "./fun/brainfuck.shaii";
+
+// text processing
+import textify from "./textProcessors/textify.shaii";
+import brainfuck from "./textProcessors/brainfuck.shaii";
+import britify from "./textProcessors/britify.shaii";
+import spongify from "./textProcessors/spongify.shaii";
+import uwuify from "./textProcessors/uwufy.shaii";
 
 // moderation commands
 import clear from "./moderation/clear.shaii";
@@ -96,6 +99,7 @@ export const getCommands = async () => {
     say,
     spongify,
     brainfuck,
+    textify,
   ];
 
   return commands;

--- a/src/commands/textProcessors/brainfuck.shaii.ts
+++ b/src/commands/textProcessors/brainfuck.shaii.ts
@@ -19,6 +19,7 @@ export default defineCommand({
         content: "bro the result is too big gonna put it in a file",
         files: [{ name: "shit.bf", attachment: Readable.from(response) }],
       };
-    } else return response;
+    }
+    return response;
   },
 });

--- a/src/commands/textProcessors/brainfuck.shaii.ts
+++ b/src/commands/textProcessors/brainfuck.shaii.ts
@@ -6,7 +6,7 @@ import { Readable } from "stream";
 
 export default defineCommand({
   name: "brainfuck",
-  category: "FUN",
+  category: "TEXT_PROCESSORS",
   usage: "brainfuck <sentence>",
   aliases: [],
   description: "Translates your sentence to brainfuck esoteric language",

--- a/src/commands/textProcessors/britify.shaii.ts
+++ b/src/commands/textProcessors/britify.shaii.ts
@@ -1,15 +1,15 @@
-import { britify } from "../../logic/logic.shaii";
+import { textToBritify } from "../../logic/logic.shaii";
 import { defineCommand } from "../../types";
 
 export default defineCommand({
   name: "britify",
   aliases: [],
   usage: "britify <sentence>",
-  category: "FUN",
+  category: "TEXT_PROCESSORS",
   description: "Transforms your sentence to british",
   requiresProcessing: false,
   execute: async (message) => {
     if (message.args.length === 0) return "tell me what u want in bri'ish cunt";
-    return britify(message.args.join(" "));
+    return textToBritify(message.args.join(" "));
   },
 });

--- a/src/commands/textProcessors/spongify.shaii.ts
+++ b/src/commands/textProcessors/spongify.shaii.ts
@@ -1,17 +1,17 @@
-import { spongify } from "../../logic/logic.shaii";
+import { textToSpongify } from "../../logic/logic.shaii";
 import { defineCommand } from "../../types";
 import { SLURS } from "../../constants";
 import { randomChoice } from "../../logic/logic.shaii";
 
 export default defineCommand({
   name: "spongify",
-  category: "FUN",
+  category: "TEXT_PROCESSORS",
   usage: "spongify <sentence>",
   aliases: [],
   description: "mAkEs YoU sPeAkInG lIkE ThAt",
   requiresProcessing: false,
   execute: async (message) => {
     if (message.args.length === 0) return `what do you want to SpOnGiFy ${randomChoice(SLURS)}`;
-    return spongify(message.args.join(" "), randomChoice([true, false]));
+    return textToSpongify(message.args.join(" "), randomChoice([true, false]));
   },
 });

--- a/src/commands/textProcessors/textify.shaii.ts
+++ b/src/commands/textProcessors/textify.shaii.ts
@@ -11,6 +11,7 @@ export default defineCommand({
   description: "Transform a sentence with a pipeline",
   requiresProcessing: true,
   execute: async (message) => {
+    // can be IMPROVED
     let pipeline: string[] = [];
     let userSentence: string[] = [];
     let isPrecArgCommand: boolean = true;

--- a/src/commands/textProcessors/textify.shaii.ts
+++ b/src/commands/textProcessors/textify.shaii.ts
@@ -1,0 +1,29 @@
+import { defineCommand } from "../../types";
+import { textify } from "../../logic/textProcessors.shaii";
+import { SLURS } from "../../constants";
+import { randomChoice } from "../../logic/logic.shaii";
+
+export default defineCommand({
+  name: "textify",
+  aliases: [],
+  usage: "textify <...processor_names> <text>",
+  category: "TEXT_PROCESSORS",
+  description: "Transform a sentence with a pipeline",
+  requiresProcessing: true,
+  execute: async (message) => {
+    let pipeline: string[] = [];
+    let userSentence: string[] = [];
+    let isPrecArgCommand: boolean = true;
+    message.args.forEach((arg) => {
+      isPrecArgCommand
+        ? ["brainfuck", "britify", "spongify", "uwufy"].includes(arg)
+          ? pipeline.push(arg)
+          : (isPrecArgCommand = false)
+        : userSentence.push(arg);
+      if (pipeline.length > 10) return "pipeline can't be longer than 10 iterators";
+    });
+    const sentence = userSentence.join(" ");
+    if (sentence.length > 2000) return `wtf your sentence is too big ${randomChoice(SLURS)}`;
+    return textify(pipeline, sentence);
+  },
+});

--- a/src/commands/textProcessors/textify.shaii.ts
+++ b/src/commands/textProcessors/textify.shaii.ts
@@ -14,13 +14,14 @@ export default defineCommand({
     // can be IMPROVED
     let pipeline: string[] = [];
     let userSentence: string[] = [];
-    let isPrecArgCommand: boolean = true;
+    let isArgCommand: boolean = true;
     message.args.forEach((arg) => {
-      isPrecArgCommand
+      isArgCommand
         ? ["brainfuck", "britify", "spongify", "uwufy"].includes(arg)
           ? pipeline.push(arg)
-          : (isPrecArgCommand = false)
+          : (isArgCommand = false, userSentence.push(arg))
         : userSentence.push(arg);
+        console.log(arg);
       if (pipeline.length > 10) return "pipeline can't be longer than 10 iterators";
     });
     const sentence = userSentence.join(" ");

--- a/src/commands/textProcessors/uwufy.shaii.ts
+++ b/src/commands/textProcessors/uwufy.shaii.ts
@@ -1,15 +1,15 @@
-import { uwufy } from "../../logic/logic.shaii";
+import { textToUwufy } from "../../logic/logic.shaii";
 import { defineCommand } from "../../types";
 
 export default defineCommand({
   name: "uwufy",
-  category: "FUN",
+  category: "TEXT_PROCESSORS",
   aliases: [],
   usage: "uwufy <sentence>",
   description: "Transforms your sentence to uwu",
   requiresProcessing: false,
   execute: async (message) => {
     if (message.args.length === 0) return "b-baka!! you need to give me s-something! uwu";
-    return uwufy(message.args.join(" "));
+    return textToUwufy(message.args.join(" "));
   },
 });

--- a/src/logic/logic.shaii.ts
+++ b/src/logic/logic.shaii.ts
@@ -464,17 +464,17 @@ export function textToSpongify(sentence: string, capsOdd: boolean = true): strin
  * @author Qexat // based (copied tbh lol) on HelgeFox's work <https://github.com/helgeh/brainfuck-text>
  */
 export function textToBrainfuck(sentence: string): string {
-  function closest(num: number, arr: number[]) {
-    var arr2 = arr.map((n) => Math.abs(num - n));
-    var min = Math.min.apply(null, arr2);
+  function closest(num: number, arr: number[]): number {
+    const arr2: number[] = arr.map((n: number) => Math.abs(num - n));
+    const min: number = Math.min.apply(null, arr2);
     return arr[arr2.indexOf(min)];
   }
 
-  function buildBaseTable(arr: number[]) {
-    var out = { value: "", append: (txt: string) => (out.value += txt) };
+  function buildBaseTable(arr: number[]): string {
+    const out = { value: "", append: (txt: string) => (out.value += txt) };
     out.append("+".repeat(10));
     out.append("[");
-    arr.forEach(function (cc) {
+    arr.forEach(function (cc: number) {
       out.append(">");
       out.append("+".repeat(cc / 10));
     });
@@ -485,23 +485,25 @@ export function textToBrainfuck(sentence: string): string {
     return out.value;
   }
 
-  var output = { value: "", append: (txt: string) => (output.value += txt) };
+  const output = { value: "", append: (txt: string) => (output.value += txt) };
 
-  var charArray = sentence.split("").map((c) => c.charCodeAt(0));
-  var baseTable = charArray.map((c) => Math.round(c / 10) * 10).filter((i, p, s) => s.indexOf(i) === p);
+  const charArray: number[] = sentence.split("").map((c) => c.charCodeAt(0));
+  const baseTable: number[] = charArray
+    .map((c: number) => Math.round(c / 10) * 10)
+    .filter((i: number, p: number, s: number[]) => s.indexOf(i) === p);
 
   output.append(buildBaseTable(baseTable));
 
-  var pos = -1;
-  charArray.forEach(function (charCode) {
-    var bestNum = closest(charCode, baseTable);
-    var bestPos = baseTable.indexOf(bestNum);
+  let pos: number = -1;
+  charArray.forEach(function (charCode: number) {
+    const bestNum: number = closest(charCode, baseTable);
+    const bestPos: number = baseTable.indexOf(bestNum);
 
-    var moveChar = pos < bestPos ? ">" : "<";
+    const moveChar: string = pos < bestPos ? ">" : "<";
     output.append(moveChar.repeat(Math.abs(pos - bestPos)));
     pos = bestPos;
 
-    var opChar = baseTable[pos] < charCode ? "+" : "-";
+    const opChar: string = baseTable[pos] < charCode ? "+" : "-";
     output.append(opChar.repeat(Math.abs(baseTable[pos] - charCode)));
     output.append(".");
     baseTable[pos] = charCode;

--- a/src/logic/logic.shaii.ts
+++ b/src/logic/logic.shaii.ts
@@ -398,7 +398,7 @@ export function calcParticipated(participatedDamage: number, totalHp: number, pl
  * @param {string} sentence the sentence to uwu-ify
  * @author azur1s
  */
-export function uwufy(sentence: string): string {
+export function textToUwufy(sentence: string): string {
   return sentence
     .replace(/(?:r|l)/g, "w")
     .replace(/(?:R|L)/g, "W")
@@ -419,7 +419,7 @@ export function uwufy(sentence: string): string {
  * @param sentence the sentence to britishize
  * @author Geoxor & MaidMarija
  */
-export function britify(sentence: string): string {
+export function textToBritify(sentence: string): string {
   // first delete any disgusting american dialect (IMPORTANT, NEEDS IMPROVEMENT)
   sentence = sentence.replace(/mom/g, "mum");
 
@@ -441,7 +441,7 @@ export function britify(sentence: string): string {
  * @param capsOdd if letters to capitalize are the odd ones (by default: true)
  * @author Qexat
  */
-export function spongify(sentence: string, capsOdd: boolean = true): string {
+export function textToSpongify(sentence: string, capsOdd: boolean = true): string {
   var newSentence = "";
   var lastNotSpaceChar;
 
@@ -459,7 +459,7 @@ export function spongify(sentence: string, capsOdd: boolean = true): string {
 }
 
 /**
- *
+ * Brainfuck a sentence
  * @param sentence the sentence to brainfuck
  * @author Qexat // based (copied tbh lol) on HelgeFox's work <https://github.com/helgeh/brainfuck-text>
  */

--- a/src/logic/logic.shaii.ts
+++ b/src/logic/logic.shaii.ts
@@ -459,6 +459,58 @@ export function spongify(sentence: string, capsOdd: boolean = true): string {
 }
 
 /**
+ * 
+ * @param sentence the sentence to brainfuck 
+ * @author Qexat // based (copied tbh lol) on HelgeFox's work <https://github.com/helgeh/brainfuck-text>
+ */
+ export function textToBrainfuck(sentence: string): string {
+	function closest(num: number, arr: number[]) {
+	  var arr2 = arr.map((n) => Math.abs(num - n));
+	  var min = Math.min.apply(null, arr2);
+	  return arr[arr2.indexOf(min)];
+	}
+  
+	function buildBaseTable(arr: number[]) {
+	  var out = { value: "", append: (txt: string) => (out.value += txt) };
+	  out.append("+".repeat(10));
+	  out.append("[");
+	  arr.forEach(function (cc) {
+		out.append(">");
+		out.append("+".repeat(cc / 10));
+	  });
+	  out.append("<".repeat(arr.length));
+	  out.append("-");
+  
+	  out.append("]");
+	  return out.value;
+	}
+  
+	var output = { value: "", append: (txt: string) => (output.value += txt) };
+  
+	var charArray = sentence.split("").map((c) => c.charCodeAt(0));
+	var baseTable = charArray.map((c) => Math.round(c / 10) * 10).filter((i, p, s) => s.indexOf(i) === p);
+  
+	output.append(buildBaseTable(baseTable));
+  
+	var pos = -1;
+	charArray.forEach(function (charCode) {
+	  var bestNum = closest(charCode, baseTable);
+	  var bestPos = baseTable.indexOf(bestNum);
+  
+	  var moveChar = pos < bestPos ? ">" : "<";
+	  output.append(moveChar.repeat(Math.abs(pos - bestPos)));
+	  pos = bestPos;
+  
+	  var opChar = baseTable[pos] < charCode ? "+" : "-";
+	  output.append(opChar.repeat(Math.abs(baseTable[pos] - charCode)));
+	  output.append(".");
+	  baseTable[pos] = charCode;
+	});
+  
+	return output.value;
+}
+
+/**
  * Gets an image url from attachments > stickers > first emoji > mentioned user avatar > author avatar > default avatar
  * @param message the discord message to fetch from
  * @author Bluskript

--- a/src/logic/logic.shaii.ts
+++ b/src/logic/logic.shaii.ts
@@ -459,55 +459,55 @@ export function spongify(sentence: string, capsOdd: boolean = true): string {
 }
 
 /**
- * 
- * @param sentence the sentence to brainfuck 
+ *
+ * @param sentence the sentence to brainfuck
  * @author Qexat // based (copied tbh lol) on HelgeFox's work <https://github.com/helgeh/brainfuck-text>
  */
- export function textToBrainfuck(sentence: string): string {
-	function closest(num: number, arr: number[]) {
-	  var arr2 = arr.map((n) => Math.abs(num - n));
-	  var min = Math.min.apply(null, arr2);
-	  return arr[arr2.indexOf(min)];
-	}
-  
-	function buildBaseTable(arr: number[]) {
-	  var out = { value: "", append: (txt: string) => (out.value += txt) };
-	  out.append("+".repeat(10));
-	  out.append("[");
-	  arr.forEach(function (cc) {
-		out.append(">");
-		out.append("+".repeat(cc / 10));
-	  });
-	  out.append("<".repeat(arr.length));
-	  out.append("-");
-  
-	  out.append("]");
-	  return out.value;
-	}
-  
-	var output = { value: "", append: (txt: string) => (output.value += txt) };
-  
-	var charArray = sentence.split("").map((c) => c.charCodeAt(0));
-	var baseTable = charArray.map((c) => Math.round(c / 10) * 10).filter((i, p, s) => s.indexOf(i) === p);
-  
-	output.append(buildBaseTable(baseTable));
-  
-	var pos = -1;
-	charArray.forEach(function (charCode) {
-	  var bestNum = closest(charCode, baseTable);
-	  var bestPos = baseTable.indexOf(bestNum);
-  
-	  var moveChar = pos < bestPos ? ">" : "<";
-	  output.append(moveChar.repeat(Math.abs(pos - bestPos)));
-	  pos = bestPos;
-  
-	  var opChar = baseTable[pos] < charCode ? "+" : "-";
-	  output.append(opChar.repeat(Math.abs(baseTable[pos] - charCode)));
-	  output.append(".");
-	  baseTable[pos] = charCode;
-	});
-  
-	return output.value;
+export function textToBrainfuck(sentence: string): string {
+  function closest(num: number, arr: number[]) {
+    var arr2 = arr.map((n) => Math.abs(num - n));
+    var min = Math.min.apply(null, arr2);
+    return arr[arr2.indexOf(min)];
+  }
+
+  function buildBaseTable(arr: number[]) {
+    var out = { value: "", append: (txt: string) => (out.value += txt) };
+    out.append("+".repeat(10));
+    out.append("[");
+    arr.forEach(function (cc) {
+      out.append(">");
+      out.append("+".repeat(cc / 10));
+    });
+    out.append("<".repeat(arr.length));
+    out.append("-");
+
+    out.append("]");
+    return out.value;
+  }
+
+  var output = { value: "", append: (txt: string) => (output.value += txt) };
+
+  var charArray = sentence.split("").map((c) => c.charCodeAt(0));
+  var baseTable = charArray.map((c) => Math.round(c / 10) * 10).filter((i, p, s) => s.indexOf(i) === p);
+
+  output.append(buildBaseTable(baseTable));
+
+  var pos = -1;
+  charArray.forEach(function (charCode) {
+    var bestNum = closest(charCode, baseTable);
+    var bestPos = baseTable.indexOf(bestNum);
+
+    var moveChar = pos < bestPos ? ">" : "<";
+    output.append(moveChar.repeat(Math.abs(pos - bestPos)));
+    pos = bestPos;
+
+    var opChar = baseTable[pos] < charCode ? "+" : "-";
+    output.append(opChar.repeat(Math.abs(baseTable[pos] - charCode)));
+    output.append(".");
+    baseTable[pos] = charCode;
+  });
+
+  return output.value;
 }
 
 /**

--- a/src/logic/logic.shaii.ts
+++ b/src/logic/logic.shaii.ts
@@ -474,7 +474,7 @@ export function textToBrainfuck(sentence: string): string {
     const out = { value: "", append: (txt: string) => (out.value += txt) };
     out.append("+".repeat(10));
     out.append("[");
-    arr.forEach(function (cc: number) {
+    arr.forEach((cc: number) => {
       out.append(">");
       out.append("+".repeat(cc / 10));
     });
@@ -495,19 +495,19 @@ export function textToBrainfuck(sentence: string): string {
   output.append(buildBaseTable(baseTable));
 
   let pos: number = -1;
-  charArray.forEach(function (charCode: number) {
-    const bestNum: number = closest(charCode, baseTable);
+  for (let i = 0; i < charArray.length; i++) {
+    const bestNum: number = closest(charArray[i], baseTable);
     const bestPos: number = baseTable.indexOf(bestNum);
 
     const moveChar: string = pos < bestPos ? ">" : "<";
     output.append(moveChar.repeat(Math.abs(pos - bestPos)));
     pos = bestPos;
 
-    const opChar: string = baseTable[pos] < charCode ? "+" : "-";
-    output.append(opChar.repeat(Math.abs(baseTable[pos] - charCode)));
+    const opChar: string = baseTable[pos] < charArray[i] ? "+" : "-";
+    output.append(opChar.repeat(Math.abs(baseTable[pos] - charArray[i])));
     output.append(".");
-    baseTable[pos] = charCode;
-  });
+    baseTable[pos] = charArray[i];
+  }
 
   return output.value;
 }

--- a/src/logic/textProcessors.shaii.ts
+++ b/src/logic/textProcessors.shaii.ts
@@ -1,0 +1,52 @@
+import { TextProcessors } from "../types";
+
+import logger from "../shaii/Logger.shaii";
+import { textToBrainfuck, textToBritify, textToSpongify, textToUwufy } from "./logic.shaii";
+
+export const textProcessors: TextProcessors = {
+  brainfuck,
+  britify,
+  spongify,
+  uwufy,
+};
+
+/**
+ * @param pipeline the order of functions to apply
+ * @param sentence the sentence to start with
+ * @returns {string} the modified sentence
+ * @author Qexat & Geoxor
+ */
+export async function textify(pipeline: string[], sentence: string) {
+  let fuckedSentence = sentence;
+
+  const functions = pipeline.map((name) => textProcessors[name]).filter((processor) => !!processor);
+  console.log(functions);
+  const bar = logger.progress("Pipelines - ", functions.length);
+  for (let i = 0; i < functions.length; i++) {
+    const start = Date.now();
+    const method = functions[i];
+    fuckedSentence = await method(fuckedSentence);
+    logger.setProgressValue(bar, i / functions.length);
+
+    // This is to avoid exp thread blocking
+    if (Date.now() - start > 10000) return fuckedSentence;
+  }
+
+  return fuckedSentence;
+}
+
+export async function brainfuck(sentence: string) {
+  return textToBrainfuck(sentence);
+}
+
+export async function britify(sentence: string) {
+  return textToBritify(sentence);
+}
+
+export async function spongify(sentence: string) {
+  return textToSpongify(sentence);
+}
+
+export async function uwufy(sentence: string) {
+  return textToUwufy(sentence);
+}

--- a/src/logic/textProcessors.shaii.ts
+++ b/src/logic/textProcessors.shaii.ts
@@ -20,7 +20,6 @@ export async function textify(pipeline: string[], sentence: string) {
   let fuckedSentence = sentence;
 
   const functions = pipeline.map((name) => textProcessors[name]).filter((processor) => !!processor);
-  console.log(functions);
   const bar = logger.progress("Pipelines - ", functions.length);
   for (let i = 0; i < functions.length; i++) {
     const start = Date.now();

--- a/src/tests/logic.test.ts
+++ b/src/tests/logic.test.ts
@@ -4,7 +4,7 @@ import { it } from "mocha";
 import {
   encodeMorse,
   decodeMorse,
-  uwufy,
+  textToUwufy,
   getWaifuNameFromFileName,
   calcSpread,
   isValidHttpUrl,
@@ -36,28 +36,28 @@ describe("⚡ Morse Encoder (encodeMorse)", () => {
   });
 });
 
-describe("⚡ UwU-ifier (uwufy)", () => {
+describe("⚡ UwU-ifier (textToUwufy)", () => {
   it("can encode a normal string", async () => {
-    const uwu = uwufy("hello world, i wanna become uwu uwuwuuw");
+    const uwu = textToUwufy("hello world, i wanna become uwu uwuwuuw");
     chai.expect(uwu).to.contain("hewwo");
     chai.expect(uwu).to.contain("wowwd");
     chai.expect(uwu).to.contain("wannya");
   });
 
   it("can preserve capitalizations", async () => {
-    const uwu = uwufy("HELLO WORLD, I WANNA BECOME UWU UWUWUUW");
+    const uwu = textToUwufy("HELLO WORLD, I WANNA BECOME UWU UWUWUUW");
     chai.expect(uwu).to.contain("HEWWO");
     chai.expect(uwu).to.contain("WOWWD");
     chai.expect(uwu).to.contain("WANNYA");
   });
 
   it("can preserve symbols", async () => {
-    const uwu = uwufy("&!*@#&");
+    const uwu = textToUwufy("&!*@#&");
     chai.expect(uwu).to.contain("&!*@#&");
   });
 
   it("can preserve numbers", async () => {
-    const uwu = uwufy("hewwo 125812985 owo");
+    const uwu = textToUwufy("hewwo 125812985 owo");
     chai.expect(uwu).to.contain("125812985");
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,11 @@ export type Coords = {
   y?: number;
   z?: number;
 };
+export type TextProcessorFn = (sentence: string, ...args: any) => Promise<string>;
+export interface TextProcessors {
+  [key: string]: TextProcessorFn;
+}
+
 export type ImageProcessorFn = (buffer: Buffer, ...args: any) => Promise<Buffer>;
 export interface ImageProcessors {
   [key: string]: ImageProcessorFn;
@@ -85,7 +90,14 @@ export type CommandExecute = (
   message: IMessage
 ) => Promise<string | Discord.ReplyMessageOptions | void> | Discord.ReplyMessageOptions | string | void;
 
-export type CommandCategories = "ECONOMY" | "FUN" | "IMAGE_PROCESSORS" | "MODERATION" | "MUSIC" | "UTILITY";
+export type CommandCategories =
+  | "ECONOMY"
+  | "FUN"
+  | "IMAGE_PROCESSORS"
+  | "TEXT_PROCESSORS"
+  | "MODERATION"
+  | "MUSIC"
+  | "UTILITY";
 
 export interface ICommand {
   /**


### PR DESCRIPTION
## New features

- New command `brainfuck` to convert text to brainfuck
- New command `textify` to pipe multiple text commands like `britify` or `uwufy`

## Modifications

- Added `TextProcessing` command type which includes four commands for now: `brainfuck`, `britify`, `spongify` and `uwufy`
- Changed logic functions of `britify`, `spongify` and `uwufy` to respectively `textToBritify`, `textToSpongify` and `textToUwufy` to avoid name interferences

Note: As always, ran `prettify` on it.