### PR TITLE
Make mention-replies work on reply

### DIFF
--- a/src/plugins/mention-replies.ts
+++ b/src/plugins/mention-replies.ts
@@ -9,9 +9,7 @@ export default definePlugin({
   events: {
     messageCreate: (message) => {
       if (
-        message.content.startsWith("<@") &&
-        message.mentions.members?.first()?.id === SHAII_ID &&
-        message.type !== "REPLY"
+        message.content.startsWith("<@" + SHAII_ID)
       ) {
         // Reply with this when they purely ping her with no question
         if (!message.content.substring(`<@!${SHAII_ID}>`.length).trim()) {


### PR DESCRIPTION
This plugin uses message.content anyway and it works
![image](https://user-images.githubusercontent.com/49094075/183457598-1cffb6fe-ebb9-4b50-8719-0d3a3ccb2f87.png)
